### PR TITLE
add draft function for atlantisom file list

### DIFF
--- a/R/atlantisom_outfilelist.R
+++ b/R/atlantisom_outfilelist.R
@@ -1,0 +1,40 @@
+#' List of Atlantis output files needed for atlantisom R package
+#'
+#' Compiles a list of file names based on user input scenario and required atlantisom inputs
+#'
+#' @param scenario Character vector. User specified model name/scenario portion of atlantis output filenames
+#'
+#' @return A character vector containing the names of all of the files to be copied to the google drive
+#'
+#' @family atlantisdrive functions
+#'
+#' @examples
+#' \dontrun{
+#' # create a list of atlantisom input files for Norweigan Barents Sea model
+#' atlantisom_outfilelist(scenario="nordic_runresults_01")
+#' 
+#' # create a list of atlantisom input files for California Current model
+#' atlantisom_outfilelist(scenario="outputCCV3")
+#' 
+#' }
+#'
+#' @export
+
+atlantisom_outfilelist <- function(scenario)){
+  
+  fileList <- NULL
+  fileList <- c(paste0(scenario, ".nc"),
+                paste0(scenario, "CATCH.nc"),
+                paste0(scenario, "PROD.nc"),
+                paste0(scenario, "ANNAGEBIO.nc"),
+                paste0(scenario, "ANNAGECATCH.nc"),
+                paste0(scenario, "BiomIndx.txt"),
+                paste0(scenario, "Catch.txt"),
+                paste0(scenario, "CatchPerFishery.txt"),
+                paste0(scenario, "DietCheck.txt"),
+                paste0(scenario, "YOY.txt")
+                )
+
+  return(fileList)
+  
+}


### PR DESCRIPTION
this is a simple function that creates a list of [`atlantisom`](https://github.com/r4atlantis/atlantisom) required files. 
this should address ATLNTS-78
I think I have them all there but we can always add (and the list may expand as we develop `atlantisom`).
note that `atlantisom` also requires atlantis input and parameter files, which I am assuming I can get from the [neus-atlantis repo](https://github.com/NOAA-EDAB/neus-atlantis). however, if I should include those here too please let me know.
please feel free to rearrange this or alter to better fit within the package
thanks!